### PR TITLE
Add config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Machine-readable logging with Superlogger:
 - Request ID for logs belonging to the same page request (notice above that each request have a different request id)
 - Hashes will be logged as key-value pairs automatically
 - Requests for assets will not be logged
-- File and line numbers 
+- File and line numbers
 - IP address of request
 
 ## Installation ##
@@ -66,6 +66,12 @@ $ bundle
 And add the following in `config/application.rb`
 ```ruby
 config.logger = Superlogger::Logger.new(STDOUT)
+
+# enable logging of ActiveRecord messages (default: false)
+config.superlogger.sql_enabled = true
+
+# replace consecutive whitespace with a single space (default: false)
+config.superlogger.squished = true
 ```
 
 ## Usage ##

--- a/lib/superlogger/active_record_log_subscriber.rb
+++ b/lib/superlogger/active_record_log_subscriber.rb
@@ -13,7 +13,7 @@ module Superlogger
     def sql(event)
       self.class.runtime += event.duration
 
-      return if Rails.env.production?
+      return unless Rails.application.config.superlogger.sql_enabled
 
       payload = event.payload
       return if IGNORE_PAYLOAD_NAMES.include?(payload[:name])

--- a/lib/superlogger/logger.rb
+++ b/lib/superlogger/logger.rb
@@ -46,7 +46,11 @@ module Superlogger
                  args.to_s
                end
 
-      output.gsub("\n", '\\n') # Escape newlines
+      if Rails.application.config.superlogger.squished
+        output.squish
+      else
+        output.gsub("\n", '\\n') # Escape newlines
+      end
     end
 
     # To silence double logging when running `rails server` in development mode

--- a/lib/superlogger/railtie.rb
+++ b/lib/superlogger/railtie.rb
@@ -1,5 +1,9 @@
 module Superlogger
   class Railtie < Rails::Railtie
+    config.superlogger = ActiveSupport::OrderedOptions.new
+    config.superlogger.sql_enabled = false
+    config.superlogger.squished = false
+
     initializer :superlogger do |app|
       Superlogger.setup(app)
     end

--- a/test/superlogger_test.rb
+++ b/test/superlogger_test.rb
@@ -10,6 +10,7 @@ class SuperloggerTest < ActiveSupport::TestCase
     Dummy::Application.configure do
       # Set to true so that routing error will not raise error in test
       config.action_dispatch.show_exceptions = true
+      config.superlogger.sql_enabled = true
     end
   end
 
@@ -156,9 +157,28 @@ class SuperloggerTest < ActiveSupport::TestCase
     assert_operator fields[7].split('=').last.to_f, :>, 0
   end
 
+  test 'disable sql' do
+    Dummy::Application.configure do
+      config.superlogger.sql_enabled = false
+    end
+    request('home/index')
+
+    fields = output[2]
+    assert_no_match 'sql=SELECT', fields[5]
+  end
+
   test 'escape new lines' do
     Rails.logger.debug var: 'first\nsecond'
 
     assert_match 'first\\nsecond', output[0].last
+  end
+
+  test 'squish whitespace' do
+    Dummy::Application.configure do
+      config.superlogger.squished = true
+    end
+    Rails.logger.debug var: "first\n\n    \n second   \t \t  third"
+
+    assert_match 'first second third', output[0].last
   end
 end


### PR DESCRIPTION
The following configuration options have been added:
- **config.superlogger.sql_enabled**

    Output ActiveRecord logs
    Disabled by default

- **config.superlogger.squished**

    Replace consecutive whitespace with a single space if enabled
    If disabled, original behaviour of escaping newlines is used
    Disabled by default