### PR TITLE
[HOTFIX] remove dash in request id

### DIFF
--- a/lib/superlogger/superlogger_middleware.rb
+++ b/lib/superlogger/superlogger_middleware.rb
@@ -41,7 +41,7 @@ module Superlogger
         Superlogger.session_id = request.env['rack.session'].id
       end
 
-      Superlogger.request_id = request.uuid.gsub('-', '')
+      Superlogger.request_id = request.uuid.try(:gsub, '-', '')
     end
   end
 end

--- a/lib/superlogger/superlogger_middleware.rb
+++ b/lib/superlogger/superlogger_middleware.rb
@@ -41,7 +41,7 @@ module Superlogger
         Superlogger.session_id = request.env['rack.session'].id
       end
 
-      Superlogger.request_id = request.uuid
+      Superlogger.request_id = request.uuid.gsub('-', '')
     end
   end
 end

--- a/lib/superlogger/version.rb
+++ b/lib/superlogger/version.rb
@@ -1,3 +1,3 @@
 module Superlogger
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
there is an unwanted dash in `0.2.0`: `2016-11-11 17:13:49.774 | 58919ae13f81 | 088189ec-2fe | I | superlogger_middleware:21 | method=GET | path=/`

