### PR TITLE
Fix forced log out when request is unverified

### DIFF
--- a/lib/superlogger/superlogger_middleware.rb
+++ b/lib/superlogger/superlogger_middleware.rb
@@ -34,9 +34,6 @@ module Superlogger
 
     def setup_logging(request)
       if request.env['rack.session']
-        # Session is lazy loaded. Force session to load if it is not already loaded.
-        request.env['rack.session'].send(:load!) unless request.env['rack.session'].id
-
         # Store session id before any actual logging is done
         Superlogger.session_id = request.env['rack.session'].id.to_s
       end

--- a/lib/superlogger/superlogger_middleware.rb
+++ b/lib/superlogger/superlogger_middleware.rb
@@ -35,7 +35,9 @@ module Superlogger
     def setup_logging(request)
       if request.env['rack.session']
         # Store session id before any actual logging is done
-        Superlogger.session_id = request.env['rack.session'].id.to_s
+        if request.env['rack.session'].id
+          Superlogger.session_id = request.env['rack.session'].id.to_s
+        end
       end
 
       Superlogger.request_id = request.uuid.try(:gsub, '-', '')


### PR DESCRIPTION
## Context

> Sessions are lazily loaded. If you don't access sessions in your action's code, they will not be loaded. Hence, you will never need to disable sessions, just not accessing them will do the job.
>
> -- https://guides.rubyonrails.org/action_controller_overview.html#accessing-the-session

By forcing the session to load, a new session will be created if one does not already exist. This means that the response sent to the client will contain the `Set-Cookie` header with a newly created `_session_id` value. While this behaviour is okay for clients making their very first request and as such do not already have an existing session, forcing the session to load results in a subtle bug in other scenarios.

For example, it is possible for the client to already be logged in to the application and as such, have an existing `_session_id` cookie. However, if a request is made with a missing or invalid Cross-Site Request Forgery (CSRF) token, the existing session will not be available for the duration of that request. As a result, if the session is forcefully loaded, a new session will be created instead. This new session will overwrite the existing session due to the `Set-Cookie` header mentioned above as the client will update its `_session_id` cookie value to the new value returned in the response. Because subsequent requests from the client will use the new value of the `_session_id` cookie which corresponds to a session that has no logged in user, the client is essentially logged out.

The implication of the above is that a malicious actor can forcefully log users out on all applications that make use of this library along with cookie-based authentication.

## Changes

Do not force the session to load so that the behaviour described above does not occur. This means that when there is no existing session, no session ID will be logged.

## How to Verify

To test this fix, I have temporarily updated All Ears's staging environment to a build that makes use of the changes made in this PR.

*Note that potentially sensitive information such as the staging URL have been deliberately omitted since this repository is public.*

1. Create a file with the name `logout.html` and the following contents:
   ```html
   <html>
     <body>
       <form action="<All Ears staging URL>/sessions/destroy" method="POST">
         <input type="submit" value="Submit request" />
       </form>
       <script>
         history.pushState('', '', '/');
         document.forms[0].submit();
       </script>
     </body>
   </html>
   ```
1. In the directory containing `logout.html`, run a web server via `python -m http.server`.
   * This is necessary as opening the file directly will result in different behaviour in all modern browsers due to stricter security policies when dealing with the file system.
1. Log into All Ears.
1. In a new browser tab, visit `localhost:8000/logout.html`.
1. In the previous browser tab, refresh the page.

The user should remain logged in where previously, they would've been forcefully logged out.

## Release Plans

Since the forced loading of sessions is a side effect that a logger should not be expected to cause, I will be releasing a new version of the gem by bumping the patch version. There should not be any downstream applications that rely on such a behaviour.

If it is necessary to maintain the same behaviour at the downstream application-level, developers can force the loading of the session on every request within the base `ApplicationController`.