### PR TITLE
Fix session ID not being logged for newly created sessions

### DIFF
--- a/lib/superlogger/superlogger_middleware.rb
+++ b/lib/superlogger/superlogger_middleware.rb
@@ -15,7 +15,8 @@ module Superlogger
     end
 
     def process_request(request)
-      setup_logging(request)
+      setup_request_id_for_logging(request)
+      setup_session_id_for_logging(request)
 
       # Start of request
       Rails.logger.info method: request.method, path: request.fullpath
@@ -27,20 +28,24 @@ module Superlogger
 
       # End of request
       duration = ((t2 - t1) * 1000).to_f.round(2)
+
+      # After the request has been processed, the session ID can change from what it was before the request
+      # was processed. As such, we need to setup the session ID again.
+      setup_session_id_for_logging(request)
+
       Rails.logger.info method: request.method, path: request.fullpath, response_time: duration, status: status
 
       [status, _headers, _response]
     end
 
-    def setup_logging(request)
-      if request.env['rack.session']
-        # Store session id before any actual logging is done
-        if request.env['rack.session'].id
-          Superlogger.session_id = request.env['rack.session'].id.to_s
-        end
-      end
-
+    def setup_request_id_for_logging(request)
       Superlogger.request_id = request.uuid.try(:gsub, '-', '')
+    end
+
+    def setup_session_id_for_logging(request)
+      return unless request.env['rack.session']&.id
+
+      Superlogger.session_id = request.env['rack.session'].id.to_s
     end
   end
 end

--- a/test/dummy/app/controllers/home_controller.rb
+++ b/test/dummy/app/controllers/home_controller.rb
@@ -2,4 +2,9 @@ class HomeController < ApplicationController
   def index
     Something.where(paper: '123', stone: '456').first
   end
+
+  def index_with_session
+    session[:force_load_session] = 'By writing to it'
+    redirect_to action: :index
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   get 'home/index'
+  get 'home/index_with_session'
 end

--- a/test/superlogger_test.rb
+++ b/test/superlogger_test.rb
@@ -36,10 +36,31 @@ class SuperloggerTest < ActiveSupport::TestCase
   test 'log format when session is not loaded' do
     request('home/index')
 
-    fields = output.first
+    fields = output[4]
     assert fields.key?("level")
     assert fields.key?("ts")
     assert fields.key?("caller")
+    assert_equal fields.key?("session_id"), false
+    assert fields.key?("request_id")
+  end
+
+  test 'log format when session is loaded' do
+    request('home/index_with_session')
+
+    # Session is not loaded before the request is processed.
+    fields = output[0]
+    assert fields.key?("level")
+    assert fields.key?("ts")
+    assert fields.key?("caller")
+    assert_equal fields.key?("session_id"), false
+    assert fields.key?("request_id")
+
+    # Session is loaded after the request is processed.
+    fields = output[4]
+    assert fields.key?("level")
+    assert fields.key?("ts")
+    assert fields.key?("caller")
+    assert fields.key?("session_id")
     assert fields.key?("request_id")
   end
 

--- a/test/superlogger_test.rb
+++ b/test/superlogger_test.rb
@@ -69,11 +69,10 @@ class SuperloggerTest < ActiveSupport::TestCase
     assert_equal Time.at(output[0]["ts"]).to_date, Date.today
   end
 
-  # TODO: To be fixed in a later PR due to a subtle bug in handling of sessions.
-  # test 'with session_id' do
-  #   env = request('home/index')
-  #   assert_match env['rack.session'].id.to_s[0..11], output[0]["session_id"]
-  # end
+  test 'with session_id' do
+    env = request('home/index_with_session')
+    assert_match env['rack.session'].id.to_s[0..11], output[4]["session_id"]
+  end
 
   test 'without session_id' do
     Rails.logger.debug var: 'test'


### PR DESCRIPTION
## Context

While working on #22, I discovered a very subtle bug with the changes made in #18 - if the session ID changes throughout the lifetime of the request, the updated session ID is not reflected in the logs.

### Mechanism

In `SuperloggerMiddleware`, the `process_request` method is called twice:

https://github.com/moexmen/superlogger/blob/f64f8dab37210af7c8e4ea6add0dc4730df06c07/lib/superlogger/superlogger_middleware.rb#L17-L33

All code before the `ensure` statement runs before the request is processed, while all code after the `ensure` statement runs after the request is processed. During the processing of the request, it is possible for the Rails session to be loaded or recreated, resulting in a different session ID from before the request was processed.

However, because `setup_logging` is only called once before the request is processed, the session ID that is logged after the request is processed does not necessarily take on the latest value of the session ID:

https://github.com/moexmen/superlogger/blob/f64f8dab37210af7c8e4ea6add0dc4730df06c07/lib/superlogger/superlogger_middleware.rb#L35-L44

This is most noticeable when the request is the first request where the session is created as the session ID will not be logged in the first request. The session ID will be logged in subsequent requests when the session is restored from the client's cookies though.

## Changes

Instead of only setting up the session ID for logging once before the request is processed, we now do it twice - once before the request is processed, and once after the request is processed. This means that the session ID logged will always be up to date.

The relevant test cases have also been updated/added.

## How to Verify

See the test cases, in particular the one titled `log format when session is loaded`.