### PR TITLE
Update publish instructions to preserve dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ rake test
 ## Publishing a New Release ##
 
 1. Bump the version in `lib/superlogger/version.rb`.
-1. Run `bundle update` to update `Gemfile.lock`.
+1. Run `bundle install` to update the version of Superlogger in `Gemfile.lock`.
 1. Open a pull request with the changes from the above steps.
 1. After the pull request is merged, publish a new release on GitHub with the same version tag.
 1. Clear all temporary files to prevent them from being bundled into the gem.


### PR DESCRIPTION
## Context

`bundle update` updates the versions of dependencies if there are new versions that meet the version constraints. This might result in unwanted dependency bumps when releasing a new version of Superlogger.

## Changes

Update the publish instructions to make use of `bundle install` instead which only bumps the Superlogger version, but not its dependencies.

## How to Verify

If you run the first 2 steps in the previous instructions, you will see that the `concurrent-ruby` gem gets bumped from v1.2.3 to v1.3.1 as of the time this PR was opened. Resetting the lock file and running the first 2 steps in the current instructions should only result in the Superlogger version being bumped, and not the version of any dependencies.